### PR TITLE
Use true timestamp to avoid "Invalid timestamp"

### DIFF
--- a/pushover.py
+++ b/pushover.py
@@ -193,7 +193,7 @@ class Client:
                 raise ValueError("{0}: invalid message parameter".format(key))
 
             if key == "timestamp" and value:
-                payload[key] = time.time()
+                payload[key] = int(time.time())
             elif key == "sound":
                 if not SOUNDS:
                     get_sounds()


### PR DESCRIPTION
With the original version i got :

python /usr/lib/python2.6/site-packages/pushover.py --token "NU2LC5g2G9jgVR9eHVLYAUmkFuPeky" --client "FWhJFb5wgV35bmzmaxeV976K1WqaFE" "Hello"
Traceback (most recent call last):
  File "/usr/lib/python2.6/site-packages/pushover.py", line 227, in <module>
    url_title=args.url_title, timestamp=True)
  File "/usr/lib/python2.6/site-packages/pushover.py", line 207, in send_message
    return MessageRequest(payload)
  File "/usr/lib/python2.6/site-packages/pushover.py", line 104, in **init**
    Request.**init**(self, "post", MESSAGE_URL, payload)
  File "/usr/lib/python2.6/site-packages/pushover.py", line 86, in **init**
    raise RequestError(self.answer["errors"])
**main**.RequestError:
==> timestamp is invalid

By casting time.time() the error disappears
