### PR TITLE
print -> return

### DIFF
--- a/pushover.py
+++ b/pushover.py
@@ -86,7 +86,7 @@ class Request:
             raise RequestError(self.answer["errors"])
 
     def __str__(self):
-        return self.answer
+        return str(self.answer)
 
 class MessageRequest(Request):
     """Class representing a message request to the Pushover API. You do not


### PR DESCRIPTION
I think this is supposed to be a return rather than a print. Print returns none and string serialization fails.
