### PR TITLE
Fix consistency in MessageRequest.poll

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -4,3 +4,4 @@ Contributors
 * Sam Birch <sam.m.birch@gmail.com>
 * Crupuk
 * Thibaut Horel <thibaut.horel@gmail.com>
+* Filip Lundborg <filip@filipl.se>

--- a/pushover.py
+++ b/pushover.py
@@ -129,10 +129,12 @@ class MessageRequest(Request):
         self.receipt = None
         if payload.get("priority", 0) == 2:
             self.receipt = self.answer["receipt"]
-        self.parameters = ["expired", "called_back", "acknowledged"]
-        for parameter in self.parameters:
-            setattr(self, parameter, False)
-            setattr(self, parameter + "_at", 0)
+        self.parameters = {"expired": "expires_at",
+                           "called_back": "called_back_at",
+                           "acknowledged": "acknowledged_at"}
+        for param, when in self.parameters.iteritems():
+            setattr(self, param, False)
+            setattr(self, when, 0)
 
     def poll(self):
         """If the message request has a priority of 2, Pushover will keep
@@ -147,18 +149,18 @@ class MessageRequest(Request):
         acknowledged, so that a typical handling of a priority-2 notification
         can look like this::
 
-            request = client.send_message("Urgent notification", priority=2)
-            while not request.poll():
+            request = client.send_message("Urgent notification", priority=2,
+                                          expire=120, retry=60)
+            while request.poll():
                 # do something
                 time.sleep(5)
         """
         if (self.receipt and not any(getattr(self, parameter)
                                      for parameter in self.parameters)):
             request = Request("get", RECEIPT_URL + self.receipt + ".json", {})
-            for parameter in self.parameters:
-                setattr(self, parameter, request.answer[parameter])
-                setattr(self, parameter + "_at",
-                        request.answer[parameter + "_at"])
+            for param, when in self.parameters.iteritems():
+                setattr(self, param, bool(request.answer[param]))
+                setattr(self, when, request.answer[when])
             return request
 
 


### PR DESCRIPTION
The help, example and actual code had different opinions on how the function
should behave. This commit make them agree.

poll() will return the base Request object until the receipt has expired, been
acknowledged or called_back upon. Once one of those three things has occurred
it returns None.

The example now has expire=120 and retry=60 since without those arguments it is
unable to send a message with priority=2.

The expired_at does not exist, it is called expires_at in the Pushover API.
This is fixed as well.

The values of expires_at, acknowledged_at and called_back_at can be found as
attributes in the MessageRequest object like before.
